### PR TITLE
Use shared type

### DIFF
--- a/src/nrdp/DataBuffer.ts
+++ b/src/nrdp/DataBuffer.ts
@@ -4,8 +4,7 @@ type DataBufferConstructor = {
     new(bytes?: number): IDataBuffer;
     new(data: string, encoding?: string): IDataBuffer;
     new(data: ArrayBuffer | IDataBuffer | Uint8Array, offset?: number, length?: number): IDataBuffer;
-    compare(lhs: string | ArrayBuffer | IDataBuffer | Uint8Array | number | number[],
-            rhs: string | ArrayBuffer | IDataBuffer | Uint8Array | number | number[]): -1 | 0 | 1;
+    compare(lhs: ConcatTypes , rhs: ConcatTypes): -1 | 0 | 1;
     concat(...args: ConcatTypes[]): IDataBuffer
     of(...args: ConcatTypes[]): IDataBuffer;
     random(size: number): IDataBuffer;


### PR DESCRIPTION
Is there any reason that `ConcatTypes` should not be used for the compare method arguments as well? If there isn't, it seems like it would be good to refactor the type list from https://github.com/ThePrimeagen/milo/blob/master/src/node/DataBuffer.ts#L433 and https://github.com/ThePrimeagen/milo/blob/master/src/types.ts#L38 into an importable/reusable type as well?